### PR TITLE
Fixed weird versioning issue for ParaView

### DIFF
--- a/OSPRay/Dockerfile
+++ b/OSPRay/Dockerfile
@@ -138,7 +138,7 @@ env LD_LIBRARY_PATH="/pvbuild/install/mpich/lib:$LD_LIBRARY_PATH"
 ######################
 
 run cd /pvbuild/src \
- && git clone --recursive https://gitlab.kitware.com/paraview/paraview-superbuild.git 
+ && git clone --recursive https://gitlab.kitware.com/paraview/paraview-superbuild.git && cd paraview-superbuild && git checkout v5.9.1 && git submodule update
 
 workdir /pvbuild/src
 run cmake -B /pvbuild/build/paraview -S /pvbuild/src/paraview-superbuild \
@@ -148,7 +148,7 @@ run cmake -B /pvbuild/build/paraview -S /pvbuild/src/paraview-superbuild \
   -DCMAKE_C_COMPILER="/pvbuild/install/gcc/bin/gcc" \
   -DENABLE_cxx11=ON \
   -Dparaview_SOURCE_SELECTION:STRING=git \
-  -Dparaview_GIT_TAG="v5.9.0" \
+  -Dparaview_GIT_TAG="v5.9.1" \
   -DENABLE_zfp:BOOL=OFF \
   -DCMAKE_BUILD_TYPE:STRING=Release \
   -DENABLE_netcdf:BOOL=OFF \


### PR DESCRIPTION
For some reason, `-Dparaview_GIT_TAG` is ignored.  We seemingly built our container for v5.9.1 without knowing that our Dockerfile was still set to 5.9.0.  This was not an issue at the time, but now there are some problems since the release of v5.10

Just building with git tag `v5.9.0` or `v5.9.1` in the `cmake` command triggers some sort of dependency issue and a line midway through the build expects a folder "5.10" to exist, which it doesn't.

So, ensuring that the cloned repository is set at v5.9.1 and then pulling the submodules ensures that there can be no version discontinuity.

It's worth noting that I am not entirely sure if this will fix the specific issue that Dr. Mateevitsi is having with building the container, but at the very least it ensures that it builds on Flick once again.